### PR TITLE
Release 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 .vscode
 .venv
-config.bin
-Downloads
-easysftp/config.bin
-easysftp/Downloads
+.cfg
+.log
+easysftp/.cfg
+easysftp/easysftp
 easysftp/__pycache__
 pyinstaller/build
 pyinstaller/dist
 easysftp/bses03/__pycache__
-easysftp/logs.txt
+easysftp/.log

--- a/docs/about.txt
+++ b/docs/about.txt
@@ -1,5 +1,5 @@
-easysftp 2.5.0
+easysftp 2.6.0
 An easy to use program for downloading files from a remote server via sftp
-Last Updated: 06-01-2024
+Last Updated: 14-01-2024
 Made by DAWN/ペンギン
 https://github.com/flamboyantpenguin/easysftp

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,4 +1,4 @@
-# easysftp 2.5.0 Console Manual
+# easysftp 2.6.0 Console Manual
 
 Info on Navigation and Basic Commands
 
@@ -28,6 +28,30 @@ Displays the files in the remote directory
 
 Displays the files in the local directory
 
+### `clearlogs`
+
+Clear logs
+
+### `viewlogs`
+
+Display logs
+
+## `showhidden`
+
+Show hidden files
+
+## `hidehidden`
+
+Hide hidden files
+
+## `clearhosts`
+
+Clear hosts keys from local database (Does not affect system known_hosts)
+
+### `set <param> <value>`
+
+Change Settings. Type `set help` for more info
+
 ### `clear`
 
 Clears the output screen
@@ -44,4 +68,4 @@ Displays version info
 
 Displays program info
 
-    Last Updated: 06-01-2024
+    Last Updated: 14-01-2024

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1,4 +1,4 @@
-----------easysftp 2.5.0 Console Manual----------
+easysftp 2.6.0 Console Manual////////////>
 
 _____Navigation_____
 For navigating/downloading files, type the number of the corressponding file/directory
@@ -17,6 +17,27 @@ _____Commands_____
 > ls
     Displays the files in the current directory
 
+> lls
+    Displays the files in the local directory
+
+> clearlogs
+    Clear logs
+
+> viewlogs
+    Display logs
+
+> showhidden
+    Shows hidden files
+
+> hidehidden
+    Hides hidden filesss
+
+> set <param> <value>
+    Change Settings. Type `set help` for more info
+
+> clearhosts
+    Clear hosts keys from local database (Does not affect system known_hosts)s
+
 > clear
     Clears the output screen
 
@@ -32,5 +53,5 @@ _____Commands_____
 > about
     Displays the about page
 
-Last Updated: 06-01-2024
+Last Updated: 14-01-2024
     

--- a/docs/settingsHelp.txt
+++ b/docs/settingsHelp.txt
@@ -1,0 +1,22 @@
+Settings Help////////////>
+
+Use set command to modify Settings
+
+Syntax: set <param> <value>
+
+> set logFileName <1/0>
+    Log file names after Download/Upload (0 by Default)
+
+> set saveFingerprints <
+    Turn off saving fingerprints locally. You have to verify hosts everytime you connect to an unauthorised system (1 by Default)
+
+> set clearLogonStartup <1/0>
+    Clear previous logs on startup (0 by Default)
+
+> set showHiddenFiles <1/0>
+    Show hidden files (0 by Default)
+
+Example: set showhidden 1
+
+Last Updated: 14-01-2024
+    

--- a/easysftp/easysftp.py
+++ b/easysftp/easysftp.py
@@ -1,28 +1,34 @@
-# easysftp console 2.5.0
+# easysftp console 2.6.0
 # An easy to use console based client for transferring files via sftp
 # Program made with paramiko
 # Made by DAWN/ペンギン
-# Last Updated: 06-01-2024
+# Last Updated: 14-01-2024
 
 
 import sys
 import cui
 import requests
 import connector
-from time import sleep, strftime
+from json import dumps
 from getpass import getpass
 from threading import Thread
-from os import mkdir, path, system, listdir
+from time import sleep, strftime
+from os import mkdir, path, system, listdir, remove, stat
 
 #os.startfile is not available for linux
 if sys.platform == 'win32': from os import startfile
 
 
 ldir = []
-version = '2.5.0'
+version = '2.6.0'
+wDir = connector.wDir
+sysfiles = ['.cfg', '.log', 'easysftp-2.6.exe', 'easysftp-2.6']
 
 
 def initialise():
+
+    if connector.settings['clearLogonStartup']:
+        clearlogs()
 
     logger('Starting Initialization', 0)
     # For fetching assets
@@ -36,13 +42,12 @@ def initialise():
         assetPath = '../docs'
 
     # Creating Local Directories
-    if path.exists('easysftp') == False: mkdir('easysftp')
-    downloadDir = 'easysftp'
+    if path.exists(wDir) == False: mkdir(wDir)
 
     # Checking config
     print('Checking for config files', end='', flush = True)
     clear()
-    if not path.exists('easysftp/config.bin'):
+    if not path.exists(wDir+'/.cfg'):
         connector.saveConfig()
     connector.loadConfig()
     if connector.previousLogin != {} and input('Do you want to load data from previous login [{}@{}] (Y/N)? '.format(connector.previousLogin['user'], connector.previousLogin['host']))[0].upper() == 'Y':
@@ -63,8 +68,8 @@ def initialise():
             return 2.4
     
     keyfile = None
-    if path.exists('easysftp/key.pub'):
-        keyfile = 'easysftp/key.pub'
+    if path.exists(wDir+'/key'):
+        keyfile = wDir+'/key'
         
     key = getpass('Enter password: ')
     r = connector.connect(data['host'], data['user'], key, data['cPath'], keyfile)
@@ -79,20 +84,21 @@ def initialise():
 
 
 def logger(message, code):
-    if path.exists('easysftp') == False: mkdir('easysftp')
-    currentTime = strftime('%Y-%m-%d/%H%M%S')
-    with open('easysftp/logs.txt', 'a+') as logFile:
-        log = '{cTime}\t:\t{action} | {actionCode}\n'.format(cTime = currentTime, action = message, actionCode = code)
+    if path.exists(wDir) == False: mkdir(wDir)
+    currentTime = strftime('%Y%m%d/%H:%M:%S')
+    
+    with open(wDir+'/.log', 'a+') as logFile:
+        log = '{cT}>\t{action} [{actionCode}]\n'.format(cT = currentTime, action = message, actionCode = code)
         logFile.write(log)
         logFile.flush()
+    if sys.platform == 'win32': system(r"attrib +H {}\.log".format(wDir))
     return 0
 
-'''
+
 def exportErrorInfo(data):
-    with open('error_{}'.format(strftime('%Y%m%d%H%M%S')), 'w') as file:
+    with open(wDir+'/errorInfo.txt', 'w') as file:
         file.write(data)
     return 0
-'''
 
 
 def tProgress(transferred, toBeTransferred):
@@ -101,6 +107,8 @@ def tProgress(transferred, toBeTransferred):
 
 def get(file):
     if file.isdigit(): file = ldir[int(file)-1]
+
+
     '''
     print('Starting Download...')
     progress = Thread(target=cui.progressBar, args=("Downloading", ))
@@ -110,38 +118,67 @@ def get(file):
     progress.join()
     print('\nFile Downloaded successfully')
     '''
-    fileDownload = Thread(target=connector.sftp.get, args=(file, downloadDir+'/'+file, tProgress))
+    fsize = cui.unitCalc(connector.sftp.lstat(file).st_size)
+    print('Downloading {} ({:.2f} {})'.format(file, fsize[0], fsize[1]))
+    fileDownload = Thread(target=connector.sftp.get, args=(file, wDir+'/'+file, tProgress))
     fileDownload.daemon = True
     fileDownload.start()
-    cui.progressBar(fileDownload, "Downloading")
+    cui.progressBar(fileDownload, file, 'D')
     fileDownload.join()
     print('\nFile Downloaded successfully')
-    logger('File Downloaded successfully', 0)
+
+    if connector.settings['logFileName']:
+        logger("Downloaded {} from {} successfully".format(file, connector.previousLogin['host']), 0)
+    else: 
+        logger('File Downloaded successfully', 0)
+    return 0
 
 
 def put(file):
-    fileUpload = Thread(target=connector.sftp.put, args=(downloadDir+'/'+file, file, tProgress))
+    fsize = cui.unitCalc(stat(file).st_size)
+    print('Uploading {} ({:.2f} {})'.format(file, fsize[0], fsize[1]))
+    fileUpload = Thread(target=connector.sftp.put, args=(wDir+'/'+file, file, tProgress))
     fileUpload.daemon = True
     fileUpload.start()
-    cui.progressBar(fileUpload, "Uploading")
+    cui.progressBar(fileUpload, file, 'U')
     fileUpload.join()
     print('\nFile Uploaded successfully')
     logger('File Uploaded Successfuly', 0)
+    return 0
 
 
 def ls():
     global ldir
+    ldir.clear()
     print('Current Directory: {}\n'.format(connector.sftp.getcwd()))
     ldir = connector.sftp.listdir()
+    if not connector.settings['showHiddenFiles']:
+         for i in list(ldir):
+            if i[0] == ".": ldir.remove(i)
     for i in ldir: print('[{}]\t\t{}'.format(ldir.index(i)+1, i))
     print()
 
 
 def lls():
     print('\n')
-    ld = listdir(downloadDir)
+    ld = listdir(wDir)
+    for i in sysfiles: 
+        if i in ld: ld.remove(i)
     for i in ld: print('[{}]\t\t{}'.format(ld.index(i)+1, i))
     print()
+    return 0
+
+
+def start(file):
+    if sys.platform == 'win32': startfile(file)
+    else: system('open {}'.format(file))
+    return 0
+
+
+def clearlogs():
+    remove(wDir+'/.log')
+    logger("Logs Cleared Successfully", 0)
+    return 0
 
     
 def clear():
@@ -157,14 +194,17 @@ def clearConsole():
 
 def displayAbout():
     cui.setColor(cui.green)
-    with open(assetPath+'/about.txt', 'r') as about:
+    with open(assetPath+'/about.txt', 'r', encoding = 'UTF-8') as about:
         print(about.read())
     cui.setColor(cui.reset)
 
 
-def displayManual():
-    with open(assetPath+'/manual.txt', 'r') as manual:
+def displayManual(p = None):
+    file = '/manual.txt'
+    if p == 'settings': file = '/settingsHelp.txt'
+    with open(assetPath+file, 'r') as manual:
         print(manual.read())
+    return 0
 
 
 def downloadUpdate(newVersion):
@@ -201,7 +241,7 @@ def checkUpdate():
                     print('Downloading easysftp-{} [{}]'.format(newVersion, cui.lAIcons[k]), flush=True, end='')
                     k = k+1 if k < len(cui.lAIcons)-1 else 0
                     clear()
-                if sys.platform == 'win32': startfile('easysftp-{}.exe'.format(newVersion[:3]))
+                if sys.platform == 'win32': start('easysftp-{}.exe'.format(newVersion[:3]))
                 else: 
                     system('tar xzf easysftp-linux-installer.tar.gz')
                     system('sudo ./install.sh')
@@ -211,18 +251,20 @@ def checkUpdate():
     except Exception as e:
         logger('Update Check Failed', 1)
         print(cui.red, 'Error Checking for Updates\n', cui.reset, sep = '')
+        return 2
 
 
 # Startup
 if sys.platform != 'linux': system('echo on')
 checkUpdate()
-print(cui.cyan, 'easyftp 2.5.0', sep='')
+print(cui.cyan, 'easyftp {}'.format(version), sep='')
 print('https://github.com/flamboyantpenguin/easysftp')
 print('An easy to use program for downloading files from a remote server via sftp', cui.reset, sep='')
 errorCode = initialise()
 if (errorCode):
     logger(connector.errorCode[errorCode], errorCode)
     print(cui.red, "{}".format(connector.errorCode[errorCode]), cui.reset, sep = '')
+    sleep(1)
     sys.exit(int(errorCode))
 
 
@@ -232,6 +274,7 @@ ls()
 while 1:
     ch = input('easysftp>')
     try:
+
         if ch.isdigit():
             ch = int(ch)
             if connector.isDir(ldir[ch-1]): connector.sftp.chdir(ldir[ch-1]); ls(); continue
@@ -244,28 +287,52 @@ while 1:
         elif ch == '.' or ch == '..':
             connector.sftp.chdir(ch)
             ls()
+
         else:
+
             if ch == 'help': displayManual()
             elif ch == 'exit': sys.exit(0)
+            
             elif 'cd' in ch: connector.sftp.chdir(ch.split()[1]); ls()
             elif 'get' in ch: get(ch.split()[1]); ls()
             elif 'put' in ch: 
-                if path.exists(downloadDir+'/'+ch.split()[1]):
+                if path.exists(wDir+'/'+ch.split()[1]):
                     put(ch.split()[1])
                     ls()
                 else:
                     logger(connector.errorCode[3], 3)
                     print(cui.red, "{}".format(connector.errorCode[3]), cui.reset, sep = '')
-            elif 'ls' in ch: ls() 
-            elif 'lls' in ch: lls() 
+            elif 'set' == ch.split()[0]:
+                if len(ch.split()) < 3 or ch.split()[1] == 'help':
+                    displayManual('settings')
+                    continue
+                connector.changeSettings(ch.split()[1], int(ch.split()[2]))
+                print(cui.green, "Done!", cui.reset, sep = '')
+            
+            elif ch == 'lls': lls() 
+            elif ch == 'ls': ls() 
             elif ch == 'cls' or ch == 'clear': clearConsole()
-            elif ch == 'version': print('\neasysftp 2.5.0 Pre-Alpha\n')
+            elif ch == 'version': print(cui.green, '\neasysftp {}\n'.format(version), cui.reset, sep = '')
+            elif ch == 'clearlogs': clearlogs(); print(cui.green, "Done!", cui.reset, sep = '')
+            elif ch == 'viewlogs': start(wDir+r'\.log'); print("Opening Logs...")
+            elif ch == 'showhidden': connector.changeSettings('showHiddenFiles', True); print(cui.green, "Done!", cui.reset, sep = '')
+            elif ch == 'hidehidden': connector.changeSettings('showHiddenFiles', False); print(cui.green, "Done!", cui.reset, sep = '')
+            elif ch == 'clearHosts': connector.hosts.clear(); connector.saveConfig(); print(cui.green, "Host Keys Cleared Successfully", cui.reset, sep = '')
+            elif ch == 'settings': print("Settings////////////>", dumps(connector.settings, indent = 6), sep = '\n')
             elif ch == 'checkupdate':
-                if checkUpdate() is False:
-                    print('The software is up to date. For downloading other versions, go to https://github.com/flamboyantpenguin/easysftp/releases')
-            elif ch == 'about': system('cls'); displayAbout()
+
+                r = checkUpdate()
+                if r is False:
+                    print(cui.green, 'The software is up to date. For downloading other versions, go to https://github.com/flamboyantpenguin/easysftp/releases', cui.reset, sep = ' ')
+                else:
+                    print(cui.red, 'Update check failed! Check your internet connection and try again', cui.reset, sep = ' ')
+
+
+            elif ch == 'about': clearConsole(); displayAbout()
+
             elif ch in ['', ' ']: continue
-            else: print('\aInvalid Command')
+            else: print(cui.red, '\aInvalid Command', cui.reset, sep = ' ')
+
     except Exception as error:
         cui.setColor(cui.red)
         print('\aUnexpected Error')

--- a/pyinstaller/easysftp.spec
+++ b/pyinstaller/easysftp.spec
@@ -28,7 +28,7 @@ exe = EXE(
     a.zipfiles,
     a.datas,
     [],
-    name='easysftp-2.5',
+    name='easysftp-2.6',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,


### PR DESCRIPTION
- `lls` command is now operational
- Added settings Users can now view/modify settings using `set` command
- Hidden files are not shown by default. Can be toggled by `showhidden`/`hidehidden`
- Added support for logging file names (turned off by default)
- Added support for turning off local key databases
- `config.bin` is renamed to `.cfg` and is hidden
- `logs.txt` is renamed to `.log` and is hidden
- Added option to view and clear logs
- Added option to delete host keys in `.cfg`
- Updated Progress Bar. Now shows file names
- Improved Error handling
- Improved event handler
- Fixed `easysftp-2.5` errors on Linux
- Minor fixes and UI improvements